### PR TITLE
Removed GA.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,13 +1,6 @@
 <!doctype html>
 <html lang=en>
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script data-cookieconsent="statistics" type="text/plain">
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-107815621-1',{ 'allow_display_features': false, 'anonymize_ip': true });
-    </script>
     <!-- Theme selector script -->
     <script>
     function toggleTheme(){

--- a/privacy.md
+++ b/privacy.md
@@ -3,21 +3,24 @@ layout: default
 title: Privacy
 description: Privacy information for infosecsapper.com
 ---
-*Last updated: 2018-05-15*  
+*Last updated: 2019-08-04*  
 # Privacy Statement
 >*"No one shall be subjected to arbitrary interference with his privacy, family, home or correspondence, nor to attacks upon his honour and reputation. Everyone has the right to the protection of the law against such interference or attacks."*  
 >Article 12, Universal Declaration of Human Rights, UN.
 
-I am a private person and, as I expect other people to respect my right to privacy, I respect theirs. This means you, as a visitor to my site, can expect me to make every feasible effort to ensure that any data collected during your visit is minimal, and that the use of that data is as transparent as possible. To that end, this page will detail the collection and use of your data, in full.
+I am a private person and, as I expect other people to respect my right to privacy, I respect theirs. This means you, as a visitor to my site, can expect me to make every feasible effort to ensure that any data collected during your visit is minimal, secure, and the methods are transparent. To that end, this page will detail the collection and use of your data in full.
 
 ## Tracking
 This website will respect your current "Do Not Track" (DNT) setting. DNT is a privacy preference you can set in your browser to prevent ad networks and other online services from collecting and sharing information about your web browsing behaviour. To learn more about DNT, visit the [Electronic Frontier Foundation's website](https://www.eff.org/issues/do-not-track).
 
-## Google Analytics
-I use Google Analytics as a third party analytics service, but not for advertising purposes. The information I collect is used for the sole purpose of analysing how the website performs and how the website's visitors, in general, navigate and use the site. My intent is to gain an understanding of the website's strengths and flaws, in order to create a better user experience. You can find out more information about how Google Analytics collects and processes data, as well as how you can control the collection of that data, by visiting [Google's support pages](https://support.google.com/analytics/answer/6004245).
+## Usage Analytics
+I do not currently measure usage of my website. This may change in the future, but it's unlikely.
+
+## Site Hosting
+This website is hosted on GitHub Pages. You can view their privacy statement [here](https://help.github.com/en/articles/github-privacy-statement). In particular, [this part](https://help.github.com/en/articles/github-privacy-statement#github-pages) relates to how your information is collected by them when you visit my website. I have no access to any data collected by GitHub.
 
 ## General Statement
-If any part of this policy changes I will publish notification of that change as far in advance as I am able. Rest assured, my reason for collecting any information about your visit is for an interest in the visit itself, not in you as an individual. As such, no personally identifiable information is collected, stored or processed by me; the closest thing to PII would be the IP address collected by Google Analytics, but that has been configured specifically to be anonymised (which can be seen in the GA code for this site). However, should you find that there is any data being erroneously collected, or if you have any questions in general, please [raise an issue](https://github.com/InfosecSapper/InfosecSapper.github.io/issues/new).
+Since removing Google Analytics from my website, I can safely say I am not collecting data about you or your visit. However, should you find that there is any data being erroneously collected, or if you have any questions in general, please [raise an issue](https://github.com/InfosecSapper/InfosecSapper.github.io/issues/new).
 
-## Cookies
+## Cookie Declaration
 {% include_relative cookies.html %}


### PR DESCRIPTION
Removed Google Analytics. It was providing no value, so it wasn't worth any potential risk to privacy.

Also updated the Privacy Statement to reflect the change, as well as clean up the wording and add mention of GitHub's data collection.